### PR TITLE
Feature/eodhp 851 refactor fastapi to reduce number of indices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.10-slim
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install gcc && \
+    apt-get clean && \
+    apt-get -y install git && \
+    rm -rf /var/lib/apt/lists/* 
+
+ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install stac-fastapi.types git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/types
+RUN pip install stac-fastapi.api git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/api
+RUN pip install stac-fastapi.extensions git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/extensions
+
+RUN pip install --no-cache-dir -e ./stac_fastapi/core
+RUN pip install --no-cache-dir ./stac_fastapi/elasticsearch[server]
+
+EXPOSE 8080
+
+#CMD ["uvicorn", "stac_fastapi.elasticsearch.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,6 @@ WORKDIR /app
 
 COPY . /app
 
-RUN pip install stac-fastapi.types git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/types
-RUN pip install stac-fastapi.api git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/api
-RUN pip install stac-fastapi.extensions git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/extensions
-
 RUN pip install --no-cache-dir -e ./stac_fastapi/core
 RUN pip install --no-cache-dir ./stac_fastapi/elasticsearch[server]
 

--- a/stac_fastapi/core/setup.py
+++ b/stac_fastapi/core/setup.py
@@ -10,9 +10,9 @@ install_requires = [
     "attrs>=23.2.0",
     "pydantic[dotenv]",
     "stac_pydantic>=3",
-    # "stac-fastapi.types @ git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/types",
-    # "stac-fastapi.api @ git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/api",
-    # "stac-fastapi.extensions @ git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/extensions"
+    "stac-fastapi.types @ git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/types",
+    "stac-fastapi.api @ git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/api",
+    "stac-fastapi.extensions @ git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/extensions",
     "orjson",
     "overrides",
     "geojson-pydantic",

--- a/stac_fastapi/core/setup.py
+++ b/stac_fastapi/core/setup.py
@@ -10,9 +10,9 @@ install_requires = [
     "attrs>=23.2.0",
     "pydantic[dotenv]",
     "stac_pydantic>=3",
-    #"stac-fastapi.types==3.0.3",
-    #"stac-fastapi.api==3.0.3",
-    #"stac-fastapi.extensions==3.0.3",
+    # "stac-fastapi.types @ git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/types",
+    # "stac-fastapi.api @ git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/api",
+    # "stac-fastapi.extensions @ git+https://github.com/EO-DataHub/eodhp-stac-fastapi.git@feature/EODHP-851-refactor-fastapi-to-reduce-number-of-indices#subdirectory=stac_fastapi/extensions"
     "orjson",
     "overrides",
     "geojson-pydantic",
@@ -20,7 +20,7 @@ install_requires = [
     "typing_extensions==4.8.0",
     "jsonschema",
     "slowapi==0.1.9",
-    "jwt"
+    "pyjwt"
 ]
 
 setup(

--- a/stac_fastapi/core/setup.py
+++ b/stac_fastapi/core/setup.py
@@ -10,9 +10,9 @@ install_requires = [
     "attrs>=23.2.0",
     "pydantic[dotenv]",
     "stac_pydantic>=3",
-    "stac-fastapi.types==3.0.0",
-    "stac-fastapi.api==3.0.0",
-    "stac-fastapi.extensions==3.0.0",
+    #"stac-fastapi.types==3.0.3",
+    #"stac-fastapi.api==3.0.3",
+    #"stac-fastapi.extensions==3.0.3",
     "orjson",
     "overrides",
     "geojson-pydantic",
@@ -20,6 +20,7 @@ install_requires = [
     "typing_extensions==4.8.0",
     "jsonschema",
     "slowapi==0.1.9",
+    "jwt"
 ]
 
 setup(

--- a/stac_fastapi/core/stac_fastapi/core/catalogs.py
+++ b/stac_fastapi/core/stac_fastapi/core/catalogs.py
@@ -1,0 +1,35 @@
+from typing import List, Optional
+
+from pydantic import model_validator
+
+from stac_pydantic.catalog import Catalog
+from stac_pydantic.api.links import Links
+from stac_pydantic.links import Relations
+from stac_pydantic.shared import StacBaseModel
+
+
+class Catalogs(StacBaseModel):
+    """
+    https://github.com/radiantearth/stac-api-spec/tree/v1.0.0/ogcapi-features#endpoints
+    https://github.com/radiantearth/stac-api-spec/tree/v1.0.0/ogcapi-features#collections-collections
+    """
+
+    links: Links
+    catalogs: List[Catalog]
+    numberMatched: Optional[int] = None
+    numberReturned: Optional[int] = None
+
+    @model_validator(mode="after")
+    def required_links(self) -> "Catalogs":
+        links_rel = []
+        for link in self.links.root:
+            links_rel.append(link.rel)
+
+        required_rels = [Relations.root, Relations.self]
+
+        for rel in required_rels:
+            assert (
+                rel in links_rel
+            ), f"STAC API Catalogs conform Catalogs pages must include a `{rel}` link."
+
+        return self

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -335,8 +335,7 @@ class CoreClient(AsyncBaseCoreClient):
             links.append(next_link)
 
         return stac_types.Collections(
-            type="Collections",
-            features=collections,
+            collections=collections,
             links=links,
             numReturned=len(collections),
             numMatched=maybe_count,
@@ -1524,8 +1523,7 @@ class EsAsyncCollectionSearchClient(AsyncBaseCollectionSearchClient):
             links.append(next_link)
 
         return stac_types.Collections(
-            type="Collections",
-            features=collections,
+            collections=collections,
             links=links,
             numReturned=len(collections),
             numMatched=maybe_count,

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -202,7 +202,7 @@ class CoreClient(AsyncBaseCoreClient):
                 ]
             )
 
-        catalogs = await self.all_catalogs(request=kwargs["request"],  auth_headers=auth_headers, root_only=True)
+        catalogs = await self.all_catalogs(request=kwargs["request"],  auth_headers=auth_headers, cat_path="root")
         for catalog in catalogs["catalogs"]:
             landing_page["links"].append(
                 {
@@ -370,13 +370,12 @@ class CoreClient(AsyncBaseCoreClient):
             extensions=[type(ext).__name__ for ext in self.extensions],
         )
     
-    async def all_catalogs(self, auth_headers: dict, cat_path: str = None, root_only: bool = False, **kwargs) -> stac_types.Catalogs:
+    async def all_catalogs(self, auth_headers: dict, cat_path: str = None, **kwargs) -> stac_types.Catalogs:
         """Read all catalogs from the database.
 
         Args:
             auth_headers (dict): The authentication headers.
             cat_path (str): The path of the parent catalog containing the catalogs.
-            root_only (bool): If True, only the top-level catalogs will be returned.
             **kwargs: Keyword arguments from the request.
 
         Returns:
@@ -390,8 +389,7 @@ class CoreClient(AsyncBaseCoreClient):
         token = request.query_params.get("token")
 
         # If root_only we only want the top-level catalogs returned
-        if not cat_path and root_only:
-            cat_path = ""
+        if cat_path == "root":
             limit = 10_000
 
         catalogs, maybe_count, next_token = await self.database.get_all_catalogs(

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -313,7 +313,7 @@ class CoreClient(AsyncBaseCoreClient):
             parent_href_url = ""
             collections_href_url = "collections"
         else:
-            parent_href_url = cat_path
+            parent_href_url = f"catalogs/{cat_path}"
             collections_href_url = f"catalogs/{cat_path}/collections"
 
         links = [
@@ -385,7 +385,7 @@ class CoreClient(AsyncBaseCoreClient):
             parent_href_url = ""
             catalogs_href_url = "catalogs"
         else:
-            parent_href_url = cat_path
+            parent_href_url = f"catalogs/{cat_path}"
             catalogs_href_url = f"catalogs/{cat_path}/catalogs"
 
         links = [
@@ -1435,17 +1435,19 @@ class EsAsyncCollectionSearchClient(AsyncBaseCollectionSearchClient):
         ]
 
         if not cat_path:
-            href_url = ""
+            parent_href_url = ""
+            collections_href_url = "collections"
         else:
-            href_url = cat_path
+            parent_href_url = f"catalogs/{cat_path}"
+            collections_href_url = f"catalogs/{cat_path}/collections"
 
         links = [
             {"rel": Relations.root.value, "type": MimeTypes.json, "href": base_url},
-            {"rel": Relations.parent.value, "type": MimeTypes.json, "href": urljoin(base_url, href_url)},
+            {"rel": Relations.parent.value, "type": MimeTypes.json, "href": urljoin(base_url, parent_href_url)},
             {
                 "rel": Relations.self.value,
                 "type": MimeTypes.json,
-                "href": urljoin(base_url, "collections"),
+                "href": urljoin(base_url, collections_href_url),
             },
         ]
 

--- a/stac_fastapi/core/stac_fastapi/core/extensions/aggregation.py
+++ b/stac_fastapi/core/stac_fastapi/core/extensions/aggregation.py
@@ -41,6 +41,9 @@ class EsAggregationExtensionGetRequest(
 ):
     """Implementation specific query parameters for aggregation precision."""
 
+    cat_path: Optional[
+        Annotated[str, Path(description="Catalog Path")]
+    ] = attr.ib(default=None)
     collection_id: Optional[
         Annotated[str, Path(description="Collection ID")]
     ] = attr.ib(default=None)
@@ -129,7 +132,7 @@ class EsAsyncAggregationClient(AsyncBaseAggregationClient):
     SUPPORTED_DATETIME_INTERVAL = {"day", "month", "year"}
     DEFAULT_DATETIME_INTERVAL = "month"
 
-    async def get_aggregations(self, collection_id: Optional[str] = None, **kwargs):
+    async def get_aggregations(self, cat_path: Optional[str] = None, collection_id: Optional[str] = None, **kwargs):
         """Get the available aggregations for a catalog or collection defined in the STAC JSON. If no aggregations, default aggregations are used."""
         request: Request = kwargs["request"]
         base_url = str(request.base_url)
@@ -331,6 +334,9 @@ class EsAsyncAggregationClient(AsyncBaseAggregationClient):
     async def aggregate(
         self,
         aggregate_request: Optional[EsAggregationExtensionPostRequest] = None,
+        cat_path: Optional[
+            Annotated[str, Path(description="Catalog Path")]
+        ] = None,
         collection_id: Optional[
             Annotated[str, Path(description="Collection ID")]
         ] = None,
@@ -434,6 +440,9 @@ class EsAsyncAggregationClient(AsyncBaseAggregationClient):
             search = self.database.apply_intersects_filter(
                 search=search, intersects=aggregate_request.intersects
             )
+
+        if cat_path:
+            search = self.database.apply_catalogs_filter(search=search, cat_path=cat_path)
 
         if aggregate_request.collections:
             search = self.database.apply_collections_filter(

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -261,7 +261,32 @@ class CatalogLinks(BaseLinks):
                 rel="queryables",
                 type=MimeTypes.json.value,
                 href=urljoin(
-                    self.base_url, f"{href_url}/queryables"
+                    self.base_url, "queryables"
+                ),
+            )
+        else:
+            return None
+        
+    def link_aggregate(self) -> Dict[str, Any]:
+        """Create the `aggregate` link."""
+        if "AggregationExtension" in self.extensions:
+            return dict(
+                rel="aggregate",
+                type=MimeTypes.json.value,
+                href=urljoin(
+                    self.base_url, "aggregate"
+                ),
+            )
+        else:
+            return None
+    def link_aggregations(self) -> Dict[str, Any]:
+        """Create the `aggregations` link."""
+        if "AggregationExtension" in self.extensions:
+            return dict(
+                rel="aggregations",
+                type=MimeTypes.json.value,
+                href=urljoin(
+                    self.base_url, "aggregations"
                 ),
             )
         else:

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -111,6 +111,7 @@ class BaseLinks:
 class CollectionLinks(BaseLinks):
     """Create inferred links specific to collections."""
 
+    catalog_path: str = attr.ib()
     collection_id: str = attr.ib()
     extensions: List[str] = attr.ib(default=attr.Factory(list))
 
@@ -119,7 +120,7 @@ class CollectionLinks(BaseLinks):
         return dict(
             rel=Relations.self.value,
             type=MimeTypes.json.value,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"{self.catalog_path}/collections/{self.collection_id}"),
         )
 
     def link_parent(self) -> Dict[str, Any]:
@@ -131,7 +132,7 @@ class CollectionLinks(BaseLinks):
         return dict(
             rel="items",
             type=MimeTypes.geojson.value,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}/items"),
+            href=urljoin(self.base_url, f"{self.catalog_path}/collections/{self.collection_id}/items"),
         )
 
     def link_queryables(self) -> Dict[str, Any]:
@@ -141,7 +142,7 @@ class CollectionLinks(BaseLinks):
                 rel="queryables",
                 type=MimeTypes.json.value,
                 href=urljoin(
-                    self.base_url, f"collections/{self.collection_id}/queryables"
+                    self.base_url, f"{self.catalog_path}/collections/{self.collection_id}/queryables"
                 ),
             )
         else:
@@ -154,7 +155,7 @@ class CollectionLinks(BaseLinks):
                 rel="aggregate",
                 type=MimeTypes.json.value,
                 href=urljoin(
-                    self.base_url, f"collections/{self.collection_id}/aggregate"
+                    self.base_url, f"{self.catalog_path}/collections/{self.collection_id}/aggregate"
                 ),
             )
         else:
@@ -167,12 +168,88 @@ class CollectionLinks(BaseLinks):
                 rel="aggregations",
                 type=MimeTypes.json.value,
                 href=urljoin(
-                    self.base_url, f"collections/{self.collection_id}/aggregations"
+                    self.base_url, f"{self.catalog_path}/collections/{self.collection_id}/aggregations"
                 ),
             )
         else:
             return None
 
+
+@attr.s
+class CatalogLinks(BaseLinks):
+    """Create inferred links specific to catalogs."""
+
+    catalog_path: str = attr.ib()
+    catalog_id: str = attr.ib()
+    extensions: List[str] = attr.ib(default=attr.Factory(list))
+
+    def link_self(self) -> Dict:
+        """Return the self link."""
+        return dict(
+            rel=Relations.self.value,
+            type=MimeTypes.json.value,
+            href=urljoin(self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}"),
+        )
+
+    def link_parent(self) -> Dict[str, Any]:
+        """Create the `parent` link."""
+        return dict(rel=Relations.parent, type=MimeTypes.json.value, href=self.base_url)
+
+    def link_collections(self) -> Dict[str, Any]:
+        """Create the `collections` link."""
+        return dict(
+            rel="collections",
+            type=MimeTypes.geojson.value,
+            href=urljoin(self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/collections"),
+        )
+    
+    def link_catalogs(self) -> Dict[str, Any]:
+        """Create the `catalogs` link."""
+        return dict(
+            rel="catalogs",
+            type=MimeTypes.geojson.value,
+            href=urljoin(self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/catalogs"),
+        )
+
+
+    def link_queryables(self) -> Dict[str, Any]:
+        """Create the `queryables` link."""
+        if "FilterExtension" in self.extensions:
+            return dict(
+                rel="queryables",
+                type=MimeTypes.json.value,
+                href=urljoin(
+                    self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/queryables"
+                ),
+            )
+        else:
+            return None
+
+    def link_aggregate(self) -> Dict[str, Any]:
+        """Create the `aggregate` link."""
+        if "AggregationExtension" in self.extensions:
+            return dict(
+                rel="aggregate",
+                type=MimeTypes.json.value,
+                href=urljoin(
+                    self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/aggregate"
+                ),
+            )
+        else:
+            return None
+
+    def link_aggregations(self) -> Dict[str, Any]:
+        """Create the `aggregations` link."""
+        if "AggregationExtension" in self.extensions:
+            return dict(
+                rel="aggregations",
+                type=MimeTypes.json.value,
+                href=urljoin(
+                    self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/aggregations"
+                ),
+            )
+        else:
+            return None
 
 @attr.s
 class PagingLinks(BaseLinks):

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -55,7 +55,7 @@ class BaseLinks:
 
     def link_self(self) -> Dict:
         """Return the self link."""
-        return dict(rel=Relations.self.value, type=MimeTypes.json.value, href=self.url)
+        return dict(rel=Relations.self.value, type=MimeTypes.json.value, href=self.base_url)
 
     def link_root(self) -> Dict:
         """Return the catalog root."""
@@ -120,29 +120,43 @@ class CollectionLinks(BaseLinks):
         return dict(
             rel=Relations.self.value,
             type=MimeTypes.json.value,
-            href=urljoin(self.base_url, f"{self.catalog_path}/collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"catalogs/{self.catalog_path}/collections/{self.collection_id}"),
         )
 
     def link_parent(self) -> Dict[str, Any]:
         """Create the `parent` link."""
-        return dict(rel=Relations.parent, type=MimeTypes.json.value, href=self.base_url)
+        if not self.catalog_path:
+            href_url = ""
+        else:
+            href_url = f"catalogs/{self.catalog_path}"
+        return dict(rel=Relations.parent, 
+                    type=MimeTypes.json.value, 
+                    href=urljoin(self.base_url, href_url))
 
     def link_items(self) -> Dict[str, Any]:
         """Create the `items` link."""
+        if not self.catalog_path:
+            href_url = ""
+        else:
+            href_url = f"catalogs/{self.catalog_path}/"
         return dict(
             rel="items",
             type=MimeTypes.geojson.value,
-            href=urljoin(self.base_url, f"{self.catalog_path}/collections/{self.collection_id}/items"),
+            href=urljoin(self.base_url, f"{href_url}collections/{self.collection_id}/items"),
         )
 
     def link_queryables(self) -> Dict[str, Any]:
         """Create the `queryables` link."""
         if "FilterExtension" in self.extensions:
+            if not self.catalog_path:
+                href_url = ""
+            else:
+                href_url = f"catalogs/{self.catalog_path}/"
             return dict(
                 rel="queryables",
                 type=MimeTypes.json.value,
                 href=urljoin(
-                    self.base_url, f"{self.catalog_path}/collections/{self.collection_id}/queryables"
+                    self.base_url, f"{href_url}collections/{self.collection_id}/queryables"
                 ),
             )
         else:
@@ -151,11 +165,15 @@ class CollectionLinks(BaseLinks):
     def link_aggregate(self) -> Dict[str, Any]:
         """Create the `aggregate` link."""
         if "AggregationExtension" in self.extensions:
+            if not self.catalog_path:
+                href_url = ""
+            else:
+                href_url = f"catalogs/{self.catalog_path}/"
             return dict(
                 rel="aggregate",
                 type=MimeTypes.json.value,
                 href=urljoin(
-                    self.base_url, f"{self.catalog_path}/collections/{self.collection_id}/aggregate"
+                    self.base_url, f"{href_url}collections/{self.collection_id}/aggregate"
                 ),
             )
         else:
@@ -164,11 +182,15 @@ class CollectionLinks(BaseLinks):
     def link_aggregations(self) -> Dict[str, Any]:
         """Create the `aggregations` link."""
         if "AggregationExtension" in self.extensions:
+            if not self.catalog_path:
+                href_url = ""
+            else:
+                href_url = f"catalogs/{self.catalog_path}/"
             return dict(
                 rel="aggregations",
                 type=MimeTypes.json.value,
                 href=urljoin(
-                    self.base_url, f"{self.catalog_path}/collections/{self.collection_id}/aggregations"
+                    self.base_url, f"{href_url}collections/{self.collection_id}/aggregations"
                 ),
             )
         else:
@@ -185,67 +207,61 @@ class CatalogLinks(BaseLinks):
 
     def link_self(self) -> Dict:
         """Return the self link."""
+        if not self.catalog_path:
+            href_url = f"catalogs/{self.catalog_id}"
+        else:
+            href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
         return dict(
             rel=Relations.self.value,
             type=MimeTypes.json.value,
-            href=urljoin(self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}"),
+            href=urljoin(self.base_url, href_url),
         )
 
     def link_parent(self) -> Dict[str, Any]:
         """Create the `parent` link."""
-        return dict(rel=Relations.parent, type=MimeTypes.json.value, href=self.base_url)
+        if not self.catalog_path:
+            href_url = ""
+        else:
+            href_url = f"catalogs/{self.catalog_path}"
+        return dict(rel=Relations.parent, type=MimeTypes.json.value, href=urljoin(self.base_url, href_url))
 
     def link_collections(self) -> Dict[str, Any]:
         """Create the `collections` link."""
+        if not self.catalog_path:
+            href_url = f"catalogs/{self.catalog_id}"
+        else:
+            href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
         return dict(
             rel="collections",
             type=MimeTypes.geojson.value,
-            href=urljoin(self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/collections"),
+            href=urljoin(self.base_url, f"{href_url}/collections"),
         )
     
     def link_catalogs(self) -> Dict[str, Any]:
         """Create the `catalogs` link."""
+        if not self.catalog_path:
+            href_url = f"catalogs/{self.catalog_id}"
+        else:
+            href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
         return dict(
             rel="catalogs",
             type=MimeTypes.geojson.value,
-            href=urljoin(self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/catalogs"),
+            href=urljoin(self.base_url, f"{href_url}/catalogs"),
         )
 
 
     def link_queryables(self) -> Dict[str, Any]:
         """Create the `queryables` link."""
         if "FilterExtension" in self.extensions:
+            if not self.catalog_path:
+                href_url = f"catalogs/{self.catalog_id}"
+            else:
+                href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
             return dict(
                 rel="queryables",
                 type=MimeTypes.json.value,
                 href=urljoin(
-                    self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/queryables"
-                ),
-            )
-        else:
-            return None
-
-    def link_aggregate(self) -> Dict[str, Any]:
-        """Create the `aggregate` link."""
-        if "AggregationExtension" in self.extensions:
-            return dict(
-                rel="aggregate",
-                type=MimeTypes.json.value,
-                href=urljoin(
-                    self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/aggregate"
-                ),
-            )
-        else:
-            return None
-
-    def link_aggregations(self) -> Dict[str, Any]:
-        """Create the `aggregations` link."""
-        if "AggregationExtension" in self.extensions:
-            return dict(
-                rel="aggregations",
-                type=MimeTypes.json.value,
-                href=urljoin(
-                    self.base_url, f"{self.catalog_path}/catalogs/{self.catalog_id}/aggregations"
+                    self.base_url, f"{href_url}/queryables"
                 ),
             )
         else:
@@ -262,7 +278,12 @@ class PagingLinks(BaseLinks):
         if self.next is not None:
             method = self.request.method
             if method == "GET":
-                href = merge_params(self.url, {"token": self.next})
+                # TODO: This is a hack to get the next link to work
+                parsed_url = urlparse(self.url)
+                netloc = parsed_url.netloc + "/"
+                query_url = self.url.split(netloc)[1]
+                new_url = self.resolve(query_url)
+                href = merge_params(new_url, {"token": self.next})
                 link = dict(
                     rel=Relations.next.value,
                     type=MimeTypes.json.value,
@@ -271,11 +292,16 @@ class PagingLinks(BaseLinks):
                 )
                 return link
             if method == "POST":
+                # TODO: This is a hack to get the next link to work
+                parsed_url = urlparse(self.url)
+                netloc = parsed_url.netloc + "/"
+                query_url = self.url.split(netloc)[1]
+                new_url = self.resolve(query_url)
                 return {
                     "rel": Relations.next,
                     "type": MimeTypes.json,
                     "method": method,
-                    "href": f"{self.request.url}",
+                    "href": f"{new_url}",
                     "body": {**self.request.postbody, "token": self.next},
                 }
 

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -304,16 +304,12 @@ class CatalogLinks(BaseLinks):
 
 
     def link_conformance(self) -> Dict[str, Any]:
-        if not self.catalog_path:
-            href_url = f"catalogs/{self.catalog_id}"
-        else:
-            href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
         return dict(
             rel="conformance",
             type=MimeTypes.json.value,
             title="STAC/WFS3 conformance classes implemented by this server",
             href=urljoin(
-                self.base_url, f"{href_url}/conformance"
+                self.base_url, "conformance"
             ),
         )
     

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -249,6 +249,41 @@ class CatalogLinks(BaseLinks):
             href=urljoin(self.base_url, f"{href_url}/catalogs"),
         )
 
+        
+    def link_aggregate(self) -> Dict[str, Any]:
+        """Create the `aggregate` link."""
+        if "AggregationExtension" in self.extensions:
+            if not self.catalog_path:
+                href_url = f"catalogs/{self.catalog_id}"
+            else:
+                href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
+            return dict(
+                rel="aggregate",
+                type=MimeTypes.json.value,
+                href=urljoin(
+                    self.base_url, f"{href_url}/aggregate"
+                ),
+            )
+        else:
+            return None
+
+
+    def link_aggregations(self) -> Dict[str, Any]:
+        """Create the `aggregations` link."""
+        if "AggregationExtension" in self.extensions:
+            if not self.catalog_path:
+                href_url = f"catalogs/{self.catalog_id}"
+            else:
+                href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
+            return dict(
+                rel="aggregations",
+                type=MimeTypes.json.value,
+                href=urljoin(
+                    self.base_url, f"{href_url}/aggregations"
+                ),
+            )
+        else:
+            return None
 
     def link_queryables(self) -> Dict[str, Any]:
         """Create the `queryables` link."""
@@ -261,36 +296,57 @@ class CatalogLinks(BaseLinks):
                 rel="queryables",
                 type=MimeTypes.json.value,
                 href=urljoin(
-                    self.base_url, "queryables"
+                    self.base_url, f"{href_url}/queryables"
                 ),
             )
         else:
             return None
-        
-    def link_aggregate(self) -> Dict[str, Any]:
-        """Create the `aggregate` link."""
-        if "AggregationExtension" in self.extensions:
-            return dict(
-                rel="aggregate",
-                type=MimeTypes.json.value,
-                href=urljoin(
-                    self.base_url, "aggregate"
-                ),
-            )
+
+
+    def link_conformance(self) -> Dict[str, Any]:
+        if not self.catalog_path:
+            href_url = f"catalogs/{self.catalog_id}"
         else:
-            return None
-    def link_aggregations(self) -> Dict[str, Any]:
-        """Create the `aggregations` link."""
-        if "AggregationExtension" in self.extensions:
-            return dict(
-                rel="aggregations",
-                type=MimeTypes.json.value,
-                href=urljoin(
-                    self.base_url, "aggregations"
-                ),
-            )
+            href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
+        return dict(
+            rel="conformance",
+            type=MimeTypes.json.value,
+            title="STAC/WFS3 conformance classes implemented by this server",
+            href=urljoin(
+                self.base_url, f"{href_url}/conformance"
+            ),
+        )
+    
+
+    def link_get_search(self) -> Dict[str, Any]:
+        if not self.catalog_path:
+            href_url = f"catalogs/{self.catalog_id}"
         else:
-            return None
+            href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
+        return dict(
+            rel="search",
+            type=MimeTypes.geojson,
+            title="STAC search",
+            href=urljoin(
+                self.base_url, f"{href_url}/search"
+            ),
+            method="GET",
+        )
+    
+    def link_post_search(self) -> Dict[str, Any]:
+        if not self.catalog_path:
+            href_url = f"catalogs/{self.catalog_id}"
+        else:
+            href_url = f"catalogs/{self.catalog_path}/catalogs/{self.catalog_id}"
+        return dict(
+            rel="search",
+            type=MimeTypes.geojson,
+            title="STAC search",
+            href=urljoin(
+                self.base_url, f"{href_url}/search"
+            ),
+            method="POST",
+        )
 
 @attr.s
 class PagingLinks(BaseLinks):

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -14,13 +14,10 @@ from stac_fastapi.types.links import ItemLinks, resolve_links
 from urllib.parse import urljoin
 from stac_pydantic.shared import MimeTypes
 
-def unhash_cat_path(hashed_cat_path: str) -> Tuple[str, str]:
-        print(f"Unhashing cat path {hashed_cat_path}")
+def regen_cat_path(hashed_cat_path: str) -> Tuple[str, str]:
         cat_path = hashed_cat_path.replace(",", "/catalogs/")
-        print(cat_path)
         if cat_path:
             cat_path = "catalogs" + "/" + cat_path
-        print(f"Unhashed cat path {cat_path}")
         return cat_path
 
 @attr.s
@@ -95,7 +92,7 @@ class ItemSerializer(Serializer):
         """
         item_id = item["id"]
         collection_id = item["collection"]
-        cat_path = unhash_cat_path(item.get("_sfapi_internal", {}).get("cat_path", ""))
+        cat_path = regen_cat_path(item.get("_sfapi_internal", {}).get("cat_path", ""))
         item_links = ItemLinks(
             catalog_path=cat_path, collection_id=collection_id, item_id=item_id, base_url=base_url
         ).create_links()
@@ -115,7 +112,7 @@ class ItemSerializer(Serializer):
             properties=item.get("properties", {}),
             links=item_links,
             assets=item.get("assets", {}),
-            _sfapi_internal={"cat_path":item.get("_sfapi_internal.cat_path", "")}
+            _sfapi_internal=item.get("_sfapi_internal", {})
         )
 
 
@@ -176,7 +173,7 @@ class CollectionSerializer(Serializer):
         collection.setdefault("assets", {})
 
         # Create the collection links using CollectionLinks
-        cat_path = unhash_cat_path(collection.get("_sfapi_internal", {}).get("cat_path", ""))
+        cat_path = regen_cat_path(collection.get("_sfapi_internal", {}).get("cat_path", ""))
         collection_links = CollectionLinks(
             catalog_path=cat_path, collection_id=collection_id, request=request, extensions=extensions
         ).create_links()
@@ -251,7 +248,7 @@ class CatalogSerializer(Serializer):
         catalog.setdefault("assets", {})
 
         # Create the catalog links using CatalogLinks
-        cat_path = unhash_cat_path(catalog.get("_sfapi_internal", {}).get("cat_path", ""))
+        cat_path = regen_cat_path(catalog.get("_sfapi_internal", {}).get("cat_path", ""))
         catalog_links = CatalogLinks(
             catalog_path=cat_path, catalog_id=catalog_id, request=request, extensions=extensions
         ).create_links()

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -272,6 +272,10 @@ class CatalogSerializer(Serializer):
                 }
             )
         for sub_collection in sub_collections:
+            if cat_path:
+                href_url = "catalogs/" + cat_path + "/"
+            else:
+                href_url = ""
             catalog["links"].append(
                 {
                     "rel": "child",

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -110,7 +110,6 @@ class ItemSerializer(Serializer):
             properties=item.get("properties", {}),
             links=item_links,
             assets=item.get("assets", {}),
-            _sfapi_internal=item.get("_sfapi_internal", {})
         )
 
 
@@ -183,7 +182,7 @@ class CollectionSerializer(Serializer):
         collection["links"] = collection_links
 
         # Pop any unnecessary keys
-        # collection.pop("_sfapi_internal", None)
+        collection.pop("_sfapi_internal", None)
 
         # Return the stac_types.Collection object
         return stac_types.Collection(**collection)
@@ -286,7 +285,7 @@ class CatalogSerializer(Serializer):
             )
 
         # Pop any unnecessary keys
-        # catalog..pop("_sfapi_internal", None)
+        catalog.pop("_sfapi_internal", None)
 
         # Return the stac_types.Catalog object
         return stac_types.Catalog(**catalog)

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -16,8 +16,6 @@ from stac_pydantic.shared import MimeTypes
 
 def regen_cat_path(hashed_cat_path: str) -> Tuple[str, str]:
         cat_path = hashed_cat_path.replace(",", "/catalogs/")
-        if cat_path:
-            cat_path = "catalogs" + "/" + cat_path
         return cat_path
 
 @attr.s
@@ -261,11 +259,15 @@ class CatalogSerializer(Serializer):
 
         # Add sub catalog and collection links
         for sub_catalog in sub_catalogs:
+            if cat_path:
+                href_url = "catalogs/" + cat_path + "/"
+            else:
+                href_url = ""
             catalog["links"].append(
                 {
                     "rel": "child",
                     "type": MimeTypes.json.value,
-                    "href": urljoin(str(request.base_url), f"{cat_path}/catalogs/{catalog_id}/catalogs/{sub_catalog[0]}"),
+                    "href": urljoin(str(request.base_url), f"{href_url}catalogs/{catalog_id}/catalogs/{sub_catalog[0]}"),
                     "title": sub_catalog[1],
                 }
             )
@@ -274,7 +276,7 @@ class CatalogSerializer(Serializer):
                 {
                     "rel": "child",
                     "type": MimeTypes.json.value,
-                    "href": urljoin(str(request.base_url), f"{cat_path}/catalogs/{catalog_id}/collections/{sub_collection[0]}"),
+                    "href": urljoin(str(request.base_url), f"{href_url}catalogs/{catalog_id}/collections/{sub_collection[0]}"),
                     "title": sub_collection[1],
                 }
             )

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -14,8 +14,10 @@ from stac_fastapi.types.links import ItemLinks, resolve_links
 from urllib.parse import urljoin
 from stac_pydantic.shared import MimeTypes
 
-def regen_cat_path(hashed_cat_path: str) -> Tuple[str, str]:
-        cat_path = hashed_cat_path.replace(",", "/catalogs/")
+def regen_cat_path(cat_path: str) -> Tuple[str, str]:
+        if cat_path == "root":
+            return ""
+        cat_path = cat_path.replace(",", "/catalogs/")
         return cat_path
 
 @attr.s

--- a/stac_fastapi/elasticsearch/setup.py
+++ b/stac_fastapi/elasticsearch/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "stac-fastapi.core==3.2.2",
+    #"stac-fastapi.core==3.2.2",
     "elasticsearch[async]==8.11.0",
     "elasticsearch-dsl==8.11.0",
     "uvicorn",

--- a/stac_fastapi/elasticsearch/setup.py
+++ b/stac_fastapi/elasticsearch/setup.py
@@ -6,11 +6,12 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    #"stac-fastapi.core==3.2.2",
+    "stac-fastapi.core==3.2.2",
     "elasticsearch[async]==8.11.0",
     "elasticsearch-dsl==8.11.0",
     "uvicorn",
     "starlette",
+    "requests",
 ]
 
 extra_reqs = {

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -69,10 +69,9 @@ search_extensions = [
     TokenPaginationExtension(),
     filter_extension,
     FreeTextExtension(),
-    
 ]
 
-if os.getenv("STAC_FASTAPI_ENABLE_TRANSACTIONS", "false") == "true":
+if os.getenv("STAC_FASTAPI_ENABLE_TRANSACTIONS", "true") == "true":
     search_extensions.append(
         TransactionExtension(
             client=TransactionsClient(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -47,12 +47,12 @@ from fastapi import Query, Path, Body
 settings = ElasticsearchSettings()
 session = Session.create_from_settings(settings)
 
-filter_extension = FilterExtension(client=EsAsyncBaseFiltersClient())
+database_logic = DatabaseLogic()
+
+filter_extension = FilterExtension(client=EsAsyncBaseFiltersClient(database=database_logic))
 filter_extension.conformance_classes.append(
     "http://www.opengis.net/spec/cql2/1.0/conf/advanced-comparison-operators"
 )
-
-database_logic = DatabaseLogic()
 
 aggregation_extension = AggregationExtension(
     client=EsAsyncAggregationClient(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -3,12 +3,13 @@
 import os
 
 from stac_fastapi.api.app import StacApi
-from stac_fastapi.api.models import create_get_request_model, create_post_request_model
+from stac_fastapi.api.models import create_get_request_model, create_post_request_model, create_get_all_request_model
 from stac_fastapi.core.core import (
     BulkTransactionsClient,
     CoreClient,
     EsAsyncBaseFiltersClient,
     TransactionsClient,
+    EsAsyncCollectionSearchClient,
 )
 from stac_fastapi.core.extensions import QueryExtension
 from stac_fastapi.core.extensions.aggregation import (
@@ -23,7 +24,9 @@ from stac_fastapi.core.session import Session
 from stac_fastapi.elasticsearch.config import ElasticsearchSettings
 from stac_fastapi.elasticsearch.database_logic import (
     DatabaseLogic,
+    create_item_index,
     create_collection_index,
+    create_catalog_index,
     create_index_templates,
 )
 from stac_fastapi.extensions.core import (
@@ -33,8 +36,13 @@ from stac_fastapi.extensions.core import (
     SortExtension,
     TokenPaginationExtension,
     TransactionExtension,
+    CollectionSearchPostExtension,
 )
 from stac_fastapi.extensions.third_party import BulkTransactionExtension
+
+from typing_extensions import Annotated
+from fastapi import Query, Path, Body
+
 
 settings = ElasticsearchSettings()
 session = Session.create_from_settings(settings)
@@ -55,32 +63,50 @@ aggregation_extension.POST = EsAggregationExtensionPostRequest
 aggregation_extension.GET = EsAggregationExtensionGetRequest
 
 search_extensions = [
-    TransactionExtension(
-        client=TransactionsClient(
-            database=database_logic, session=session, settings=settings
-        ),
-        settings=settings,
-    ),
-    BulkTransactionExtension(
-        client=BulkTransactionsClient(
-            database=database_logic,
-            session=session,
-            settings=settings,
-        )
-    ),
     FieldsExtension(),
     QueryExtension(),
     SortExtension(),
     TokenPaginationExtension(),
     filter_extension,
     FreeTextExtension(),
+    
 ]
+
+if os.getenv("STAC_FASTAPI_ENABLE_TRANSACTIONS", "false") == "true":
+    search_extensions.append(
+        TransactionExtension(
+            client=TransactionsClient(
+                database=database_logic, session=session, settings=settings
+            ),
+            settings=settings,
+        ),
+    )
+    ## Disable for time being
+    # search_extensions.append(
+    #     BulkTransactionExtension(
+    #     client=BulkTransactionsClient(
+    #         database=database_logic,
+    #         session=session,
+    #         settings=settings,
+    #     )
+    # )
+else:
+    search_extensions.append(
+        CollectionSearchPostExtension(
+            client=EsAsyncCollectionSearchClient(
+                database=database_logic, session=session, settings=settings
+            ),
+            settings=settings,
+        )
+    )
 
 extensions = [aggregation_extension] + search_extensions
 
 database_logic.extensions = [type(ext).__name__ for ext in extensions]
 
 post_request_model = create_post_request_model(search_extensions)
+
+
 
 api = StacApi(
     title=os.getenv("STAC_FASTAPI_TITLE", "stac-fastapi-elasticsearch"),
@@ -93,6 +119,7 @@ api = StacApi(
     ),
     search_get_request_model=create_get_request_model(search_extensions),
     search_post_request_model=post_request_model,
+    search_get_all_request_model=create_get_all_request_model(search_extensions),
     route_dependencies=get_route_dependencies(),
 )
 app = api.app
@@ -105,7 +132,10 @@ setup_rate_limit(app, rate_limit=os.getenv("STAC_FASTAPI_RATE_LIMIT"))
 @app.on_event("startup")
 async def _startup_event() -> None:
     await create_index_templates()
+    # for now we have a single index for each STAC data type
+    await create_item_index()
     await create_collection_index()
+    await create_catalog_index()
 
 
 def run() -> None:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -130,11 +130,13 @@ setup_rate_limit(app, rate_limit=os.getenv("STAC_FASTAPI_RATE_LIMIT"))
 
 @app.on_event("startup")
 async def _startup_event() -> None:
-    await create_index_templates()
-    # for now we have a single index for each STAC data type
-    await create_item_index()
-    await create_collection_index()
-    await create_catalog_index()
+    # Only create indices when write operations are enabled
+    if os.getenv("STAC_FASTAPI_ENABLE_TRANSACTIONS", "false") == "true":
+        await create_index_templates()
+        # for now we have a single index for each STAC data type
+        await create_item_index()
+        await create_collection_index()
+        await create_catalog_index()
 
 
 def run() -> None:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1873,12 +1873,12 @@ class DatabaseLogic:
         gen_cat_path = self.generate_cat_path(cat_path)
 
         if cat_path == "root":
-            combi_catalog_id = catalog_id
+            combi_cat_path = catalog_id
         else:
             catalog_id = catalog["id"]
-            combi_catalog_id = gen_cat_path + "||" + catalog_id
+            combi_cat_path = gen_cat_path + "||" + catalog_id
 
-        if await self.client.exists(index=CATALOGS_INDEX, id=combi_catalog_id):
+        if await self.client.exists(index=CATALOGS_INDEX, id=combi_cat_path):
             raise ConflictError(f"Catalog {catalog_id} already exists")
         
         parent_catalog = None
@@ -1918,7 +1918,7 @@ class DatabaseLogic:
 
         await self.client.index(
             index=CATALOGS_INDEX,
-            id=combi_catalog_id,
+            id=combi_cat_path,
             document=catalog,
             refresh=refresh,
         )
@@ -1958,7 +1958,7 @@ class DatabaseLogic:
             combi_cat_path = gen_cat_path + "||" + catalog["id"]
         else:
             combi_cat_path = catalog["id"]
-        
+
         try:
             prev_catalog = await self.client.get(index=CATALOGS_INDEX, id=combi_cat_path)
         except exceptions.NotFoundError:


### PR DESCRIPTION
## Update for EODHP Functionality
- Based on a more up to date STAC-FastApi release
- Added nested catalogs
- Reduced number of indices to 3, one for catalogs, one for collections and one for items
- Adding `cat_path` to any endpoints that required catalog specific functionality, e.g. `/collections` and `/search`
- Updated collection-search extension
- Added auth header usage
- Added access-control functionality to restrict access to private catalogs and allow publishing of catalogs and collections
- I have not yet updated the unit tests, as this will be a lot of work and we first need to get this working on test to improve usability for app-devs