### PR TITLE
Update return to be item not item_id when authorised to access single…

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1064,7 +1064,7 @@ class DatabaseLogic:
                 raise HTTPException(status_code=401, detail="User is not authenticated")
             for workspace in workspaces:
                 if workspace == access_control.get("owner", ""):
-                    return item_id
+                    return item
             raise HTTPException(status_code=403, detail="User is not authorized to access this item")
 
         return item


### PR DESCRIPTION
## Quick Bugfix
- The `get_one_item` function was incorrectly returning the `item_id` for a private item when the user is authorized
- It should instead return the item itself