### PR TITLE
Increase the number of shards to use for our indices from 1 to 12.

### DIFF
--- a/README-eodh.md
+++ b/README-eodh.md
@@ -1,5 +1,6 @@
 For testing locally, try:
 
+* You might need `sudo /usr/sbin/sysctl -w vm.max_map_count=262144` if vm.max_map_count is less than 64k.
 * `make image-deploy-es` to build an image using `dockerfiles/Dockerfile.dev.es`
 * `docker-compose up app-elasticsearch` to start ES and stac-fastapi
 * `curl http://localhost:8080/` to see the root Catalog. Add api.html to use the transaction API to add more records.

--- a/README-eodh.md
+++ b/README-eodh.md
@@ -1,0 +1,6 @@
+For testing locally, try:
+
+* `make image-deploy-es` to build an image using `dockerfiles/Dockerfile.dev.es`
+* `docker-compose up app-elasticsearch` to start ES and stac-fastapi
+* `curl http://localhost:8080/` to see the root Catalog. Add api.html to use the transaction API to add more records.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.9'
 services:
   app-elasticsearch:
     container_name: stac-fastapi-es
-    image: stac-utils/stac-fastapi-es
+    image: stac-fastapi-elasticsearch
     restart: always
     build:
       context: .
@@ -22,6 +22,7 @@ services:
       - ES_USE_SSL=false
       - ES_VERIFY_CERTS=false
       - BACKEND=elasticsearch
+      - STAC_FASTAPI_ENABLE_TRANSACTIONS=true
     ports:
       - "8080:8080"
     volumes:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -67,6 +67,9 @@ ES_ITEMS_SETTINGS = {
     "index": {
         "sort.field": list(DEFAULT_SORT.keys()),
         "sort.order": [v["order"] for v in DEFAULT_SORT.values()],
+
+        # This is set to 12 to make it easy to spread across 1, 2, 3, 4, 6 or 12 nodes.
+        "number_of_shards": 12,
     },
     "analysis": {
         "tokenizer": {
@@ -87,6 +90,10 @@ ES_ITEMS_SETTINGS = {
 }
 
 ES_COLLECTIONS_SETTINGS = {
+    "index": {
+        # This is set to 12 to make it easy to spread across 1, 2, 3, 4, 6 or 12 nodes.
+        "number_of_shards": 12,
+    },
     "analysis": {
         "tokenizer": {
             "edge_ngram_tokenizer": {


### PR DESCRIPTION
This increases the number of shards specified to 12. This makes it easier to use 1, 2, 3, 4, 6 or 12 nodes for Elasticsearch as our needs change.
