### PR TITLE
Add timeout config, read from env var or default to 60s

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/config.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/config.py
@@ -50,6 +50,8 @@ def _es_config() -> Dict[str, Any]:
     if (u := os.getenv("ES_USER")) and (p := os.getenv("ES_PASS")):
         config["http_auth"] = (u, p)
 
+    config["timeout"] = int(os.getenv("ES_TIMEOUT", "60"))
+
     return config
 
 


### PR DESCRIPTION
## Increase Elasticsearch Timeout
- Increase default to 60 seconds
- Can be configured via environment variable in future